### PR TITLE
Fix for GCC lost in SDK v8.0 update

### DIFF
--- a/nordic-sdk/components/softdevice/s110/headers/nrf_svc.h
+++ b/nordic-sdk/components/softdevice/s110/headers/nrf_svc.h
@@ -53,7 +53,7 @@
   { \
     __asm( \
         "svc %0\n" \
-        "bx r14" : : "I" (number) : "r0" \
+        "bx r14" : : "I" ((uint32_t)number) : "r0" \
     ); \
   }    \
   _Pragma("GCC diagnostic pop")


### PR DESCRIPTION
This fix was previously in the library but was lost when porting over to new SDK