### PR TITLE
Init support for additional descriptors (writing user desc, server client config, pres. fmt, and ext props)

### DIFF
--- a/source/btle/custom/custom_helper.h
+++ b/source/btle/custom/custom_helper.h
@@ -18,7 +18,7 @@
 #define _CUSTOM_HELPER_H_
 
 #include "common/common.h"
-#include "nrf_ble.h"
+#include "ble.h"
 #include "ble/UUID.h"
 #include "ble/GattCharacteristic.h"
 
@@ -33,17 +33,9 @@ ble_uuid_t custom_convert_to_nordic_uuid(const UUID &uuid);
 
 error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      ble_uuid_t               *p_uuid,
-                                     uint8_t                   properties,
-                                     SecurityManager::SecurityMode_t requiredSecurity,
-                                     uint8_t                  *p_data,
-                                     uint16_t                  length,
-                                     uint16_t                  max_length,
-                                     bool                      has_variable_len,
-                                     const uint8_t            *userDescriptionDescriptorValuePtr,
-                                     uint16_t                  userDescriptionDescriptorValueLen,
-                                     bool                      readAuthorization,
-                                     bool                      writeAuthorization,
-                                     ble_gatts_char_handles_t *p_char_handle);
+                                    GattCharacteristic        *p_char,
+                                    ble_gatts_char_handles_t  *p_char_handle
+);
 
 error_t custom_add_in_descriptor(uint16_t                      char_handle,
                                      ble_uuid_t               *p_uuid,


### PR DESCRIPTION
There was some support for descriptors, but the Nordic stack doesn't deal with all descriptors in a consistent way.  This update provides support for writing the user description, including a presentation format, the server client config, and extended props)

All can now show up in the GATT table.  Writing to the user description has been tested. 

Further enhancements would include better control over permissions. 